### PR TITLE
Adding licensing information to each file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
 #Folders Ignore
 Bin/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
 cmake_minimum_required(VERSION 2.8.0 FATAL_ERROR)
 
 set(PROJECT_NAME ctsa)

--- a/header/ctsa.h
+++ b/header/ctsa.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
 * arma.h
 *

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 set(SOURCE_FILES   	autoutils.c

--- a/src/autoutils.c
+++ b/src/autoutils.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include "autoutils.h"
 
 static int runstattests(double *x, int N, const char * test,const char *mtype,double alpha) {

--- a/src/autoutils.h
+++ b/src/autoutils.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #ifndef AUTOUTILS_H_
 #define AUTOUTILS_H_
 

--- a/src/boxcox.c
+++ b/src/boxcox.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include "boxcox.h"
 
 int checkConstant(double *x, int N) {

--- a/src/boxcox.h
+++ b/src/boxcox.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #ifndef BOXCOX_H_
 #define BOXCOX_H_
 

--- a/src/boxjenkins.c
+++ b/src/boxjenkins.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * boxjenkins.c
  *

--- a/src/boxjenkins.h
+++ b/src/boxjenkins.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * boxjenkins.h
  *

--- a/src/brent.c
+++ b/src/brent.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// see https://people.math.sc.edu/Burkardt/f_src/brent/brent.html
 #include "brent.h"
 
 /*

--- a/src/brent.h
+++ b/src/brent.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// see https://people.math.sc.edu/Burkardt/f_src/brent/brent.html
 #ifndef BRENT_H_
 #define BRENT_H_
 

--- a/src/conjgrad.c
+++ b/src/conjgrad.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include "conjgrad.h"
 
 static int richolu(double *A,int N, int stride, double *U22) {

--- a/src/conjgrad.h
+++ b/src/conjgrad.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #ifndef CONJGRAD_H_
 #define CONJGRAD_H_
 

--- a/src/conv.c
+++ b/src/conv.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * conv.c
  *

--- a/src/conv.h
+++ b/src/conv.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * conv.h
  *

--- a/src/ctsa.c
+++ b/src/ctsa.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include "ctsa.h"
 
 arima_object arima_init(int p, int d, int q, int N) {

--- a/src/ctsa.h
+++ b/src/ctsa.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
 * arma.h
 *

--- a/src/dist.c
+++ b/src/dist.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * dist.c
 
@@ -43,6 +44,8 @@ double eps(double x) {
 	return y;
 }
 
+// SPDX-License-Identifier: MIT
+// See https://github.com/geographiclib/geographiclib
 double log1p(double x) {
 	/*
 	 * This log(1+x) algorithm is courtesy of Charles kerney and John D Cook
@@ -77,6 +80,8 @@ double factorial(int N) {
 	return ans;
 }
 
+// Software released before the Berne Convention Implementation Act of 1988 without an explicit copyright notice are public-domain software
+// SPDX-License-Identifier: CC0
 double gamma(double x) {
 	/*
 	 * This C program code is based on  W J Cody's fortran code.
@@ -217,6 +222,8 @@ double gamma(double x) {
 	return oup;
 }
 
+// Software released before the Berne Convention Implementation Act of 1988 without an explicit copyright notice are public-domain software
+// SPDX-License-Identifier: CC0
 double gamma_log(double x) {
 	/*
 	 * This C program code is based on  W J Cody's fortran code.
@@ -537,6 +544,8 @@ double qgamma(double x, double a) {
 	
 }
 
+// This is Public Domain in the US (work of US government employees)
+// SPDX-License-Identifier: CC0
 double bfrac(double x,double a, double b, int* ctr) {
 	double d2m,d2m1,a0,b0,a1,b1,am,bm,g,g0,delta,a1m,a2m,del;
 	int m;
@@ -588,6 +597,8 @@ double bfrac(double x,double a, double b, int* ctr) {
 	 return g;
 }
 
+// This is Public Domain in the US (work of US government employees)
+// SPDX-License-Identifier: CC0
 double ibeta_appx(double x, double a , double b) {
 	double oup,abx,c2,w1,w2,num,den;
 	/*
@@ -619,6 +630,8 @@ double ibeta_appx(double x, double a , double b) {
 	
 }
 
+// This is Public Domain in the US (work of US government employees)
+// SPDX-License-Identifier: CC0
 double ibeta(double x, double a , double b) {
 	double oup,temp;
 	int ctrlint;
@@ -688,6 +701,8 @@ double ibetad(double x, double a , double b) {
 	return oup;
 }
 
+// This is Public Domain in the US (work of US government employees)
+// SPDX-License-Identifier: CC0
 double betapdf(double x, double a , double b) {
 	double oup,la,lb;
 	/*
@@ -742,6 +757,7 @@ double betacdf(double x, double a , double b) {
 	
 }
 
+// SPDX-License-Identifier: LGPL-3.0-or-later
 double r8_max ( double x, double y )
 
 /******************************************************************************/
@@ -783,6 +799,7 @@ double r8_max ( double x, double y )
   return value;
 }
 
+// SPDX-License-Identifier: LGPL-3.0-or-later
 double betainv(double alpha, double p, double q) {
 	/*
 	 *   Author:

--- a/src/dist.h
+++ b/src/dist.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * dist.h
  *

--- a/src/emle.c
+++ b/src/emle.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include "emle.h"
 
@@ -388,7 +389,9 @@ static void regres(int np,int nrbar,double *rbar, double *thetab, double *beta) 
 	}
 }
 
-
+// Software released before the Berne Convention Implementation Act of 1988 without an explicit copyright notice are public-domain software
+// Copyright: Royal Statistical Society - free to redistribute but no fee for redistribution
+// SPDX-License-Identifier: CC0
 int starma(int ip, int iq,double *phi,double *theta,double *A,double *P,double *V) {
 	int ifault,ir,np,nrbar,i,ind,j,ir1,irank,ifail;
 	int npr, npr1, ind1, ind2, indj,indi,indn;
@@ -721,6 +724,9 @@ void karma(int ip,int iq,double *phi,double *theta,double *A,double *P,double*V,
 	free(E);
 }
 
+// Software released before the Berne Convention Implementation Act of 1988 without an explicit copyright notice are public-domain software
+// Copyright: Royal Statistical Society - free to redistribute but no fee for redistribution
+// SPDX-License-Identifier: CC0
 int forkal(int ip,int iq,int id,double *phi,double*theta,double *delta,int N,double *W,double *resid,int il,double *Y,double *AMSE) {
 	int ifault,ir,np,k,nrbar,ird,irz;
 	double *A,*P,*V,*store,*xrow;

--- a/src/emle.h
+++ b/src/emle.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
 * emle.h
 *

--- a/src/erfunc.c
+++ b/src/erfunc.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /*
  *
  * This program is modified C translation of ACM TOMS 708 erf and erfc

--- a/src/erfunc.h
+++ b/src/erfunc.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * erfunc.h
  *

--- a/src/errors.c
+++ b/src/errors.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include "errors.h"
 
 static void pe(double *predicted, double *actual, int N,double *err) {

--- a/src/errors.h
+++ b/src/errors.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #ifndef ERRORS_H_
 #define ERRORS_H_
 

--- a/src/filter.c
+++ b/src/filter.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * filter.c
  *

--- a/src/filter.h
+++ b/src/filter.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * filter.h
  *

--- a/src/hsfft.c
+++ b/src/hsfft.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * hsfft.c
  *

--- a/src/hsfft.h
+++ b/src/hsfft.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * hsfft.h
  *

--- a/src/initest.c
+++ b/src/initest.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * initest.c
  *
@@ -85,6 +86,8 @@ void ma_inn(double *inp, int N,int q, double* theta, int lag) {
 	free(thetap);
 }
 
+// Free to use for any purpose, so ~CC0?
+// SPDX-License-Identifier: CC0
 void burgalg(double *x, int N, int p, double *phi,double *var) {
 	int i, j, N1, p1;
 	double dk,u,temp1,temp2;

--- a/src/initest.h
+++ b/src/initest.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * initest.h
  *

--- a/src/lls.c
+++ b/src/lls.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * lls.c
  *
@@ -474,6 +475,7 @@ void bidiag_orth(double *A, int M, int N,double *U,double *V) {
 }
 
 
+// SPDX-License-Identifier: MIT
 int svd_gr(double *A,int M,int N,double *U,double *V,double *q) {
 	int i,j,k,l,t,t2,ierr,cancel,iter,l1;
 	double eps,g,x,s,temp,f,h,scale,c,y,z;
@@ -785,6 +787,7 @@ int svd_gr(double *A,int M,int N,double *U,double *V,double *q) {
 }
 
 
+// SPDX-License-Identifier: MIT
 int svd_gr2(double *A,int M,int N,double *U,double *V,double *q) {
 	int i,j,k,l,t,t2,ierr,cancel,iter,l1;
 	double eps,g,x,s,temp,f,h,tol,c,y,z;
@@ -1081,6 +1084,8 @@ int svd_gr2(double *A,int M,int N,double *U,double *V,double *q) {
 	return ierr;
 }
 
+
+// SPDX-License-Identifier: MIT
 int minfit(double *AB,int M,int N,int P,double *q) {
 	int i,j,k,l,t,t2,ierr,cancel,iter,l1,np,n1;
 	double eps,g,x,s,temp,f,h,tol,c,y,z;

--- a/src/lls.h
+++ b/src/lls.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * lls.h
  *

--- a/src/lnsrchmp.c
+++ b/src/lnsrchmp.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include "lnsrchmp.h"
 
 /*

--- a/src/lnsrchmp.h
+++ b/src/lnsrchmp.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #ifndef LNSRCHMP_H_
 #define LNSRCHMP_H_
 

--- a/src/matrix.c
+++ b/src/matrix.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include "matrix.h"
 

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * matrix.h
  *

--- a/src/neldermead.c
+++ b/src/neldermead.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include "neldermead.h"
 

--- a/src/neldermead.h
+++ b/src/neldermead.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * neldormead.h
  *

--- a/src/newtonmin.c
+++ b/src/newtonmin.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include "newtonmin.h"
 
 /*

--- a/src/newtonmin.h
+++ b/src/newtonmin.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #ifndef NEWTONMIN_H_
 #define NEWTONMIN_H_
 

--- a/src/nls.c
+++ b/src/nls.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * nls.c
  *

--- a/src/nls.h
+++ b/src/nls.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * nls.h
  *

--- a/src/optimc.c
+++ b/src/optimc.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * optimize.c
  *

--- a/src/optimc.h
+++ b/src/optimc.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * optimc.h
  *

--- a/src/pdist.c
+++ b/src/pdist.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * pdist.c
  *

--- a/src/pdist.h
+++ b/src/pdist.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * pdist.h
  *

--- a/src/polyroot.c
+++ b/src/polyroot.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include "polyroot.h"
 
 /*

--- a/src/polyroot.h
+++ b/src/polyroot.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
 * polyroot.h
 *

--- a/src/pred.c
+++ b/src/pred.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * pred.c
  *

--- a/src/pred.h
+++ b/src/pred.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * pred.h
  *

--- a/src/real.c
+++ b/src/real.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * real.c
  *

--- a/src/real.h
+++ b/src/real.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * real.h
  *

--- a/src/regression.c
+++ b/src/regression.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * regression.c
  *

--- a/src/regression.h
+++ b/src/regression.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * regression.h
  *

--- a/src/seastest.c
+++ b/src/seastest.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include "seastest.h"
 
 static void findMeans(double *x, int N, int stride, double *means) {

--- a/src/seastest.h
+++ b/src/seastest.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #ifndef SEASTEST_H_
 #define SEASTEST_H_
 

--- a/src/secant.c
+++ b/src/secant.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include "secant.h"
 
 /*

--- a/src/secant.h
+++ b/src/secant.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #ifndef SECANT_H_
 #define SECANT_H_
 

--- a/src/spectrum.c
+++ b/src/spectrum.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * spectrum.c
  *

--- a/src/spectrum.h
+++ b/src/spectrum.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * spectrum.h
  *

--- a/src/stats.c
+++ b/src/stats.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * stats.c
  *

--- a/src/stats.h
+++ b/src/stats.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * stats.h
  *

--- a/src/stl.c
+++ b/src/stl.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include "stl.h"
 
 /*

--- a/src/stl.h
+++ b/src/stl.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #ifndef STL_H_
 #define STL_H_
 

--- a/src/talg.c
+++ b/src/talg.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * talg.c
  *

--- a/src/talg.h
+++ b/src/talg.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
  * talg.h
  *

--- a/src/unitroot.c
+++ b/src/unitroot.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include "unitroot.h"
 
 /*

--- a/src/unitroot.h
+++ b/src/unitroot.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #ifndef UNITROOT_H_
 #define UNITROOT_H_
 

--- a/src/wavefilt.c
+++ b/src/wavefilt.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
 * Copyright (c) 2014, Rafat Hussain
 * Copyright (C) 2016  Holger Nahrstaedt

--- a/src/wavefilt.h
+++ b/src/wavefilt.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
 Copyright (c) 2014, Rafat Hussain
 Copyright (c) 2016, Holger Nahrstaedt

--- a/src/waveletarima.c
+++ b/src/waveletarima.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include "waveletarima.h"
 
 void waveletarima(double *x, int N, char *wname, int levels,int p, int q, double *forecasts, int lengthfor) {

--- a/src/waveletarima.h
+++ b/src/waveletarima.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #ifndef WAVELETARIMA_H_
 #define WAVELETARIMA_H_
 #include "wavelib.h"

--- a/src/wavelib.c
+++ b/src/wavelib.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
   Copyright (c) 2014, Rafat Hussain
 */

--- a/src/wavelib.h
+++ b/src/wavelib.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #ifndef WAVELIB_H_
 #define WAVELIB_H_
 

--- a/src/wtmath.c
+++ b/src/wtmath.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
 Copyright (c) 2018, Rafat Hussain
 */

--- a/src/wtmath.h
+++ b/src/wtmath.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
 Copyright (c) 2014, Rafat Hussain
 */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
 add_executable(acftest acftest.c)
 
 target_link_libraries(acftest ctsalib m)

--- a/test/acftest.c
+++ b/test/acftest.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/test/arimatest.c
+++ b/test/arimatest.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/test/artest.c
+++ b/test/artest.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/test/artest2.c
+++ b/test/artest2.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/test/autoarimatest1.c
+++ b/test/autoarimatest1.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/test/autoarimatest2.c
+++ b/test/autoarimatest2.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/test/autoarimatest3.c
+++ b/test/autoarimatest3.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/test/dwttests.c
+++ b/test/dwttests.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/test/misctests.c
+++ b/test/misctests.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/test/pacftest.c
+++ b/test/pacftest.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/test/sarimatest.c
+++ b/test/sarimatest.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/test/sarimaxtest1.c
+++ b/test/sarimaxtest1.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/test/sarimaxtest2.c
+++ b/test/sarimaxtest2.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/test/sarimaxtest3.c
+++ b/test/sarimaxtest3.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/tsdata/tsdata.c
+++ b/tsdata/tsdata.c
@@ -1,0 +1,1 @@
+// SPDX-License-Identifier: BSD-3-Clause

--- a/tsdata/tsdata.h
+++ b/tsdata/tsdata.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 #ifndef TSDATA_H_
 #define TSDATA_H_
 


### PR DESCRIPTION
I'm sorry it took me way longer than I thought, but here it is: I have added the SPDX License Identifiers to each file as well as sometimes specific functions (when a function has a different license than the rest of the file). The latter is not a standard use of SPDX, but this is the only easy way I found (short of splitting the files based on licensing which is not so satisfactory). 

The most complicated cases have required some back and forth communication with some algorithm's authors but with what I learned this way (including comments on other author's US federal employment status, leading to automatic public domain copyright for their work) we should have a relatively solid licensing information.

Overall, the code is a mix of MIT, BSD-3-Clause, LGPL-3.0-or-later and CC0 (I've used CC0 for all public domain (PD) code as there is no simple "public domain" license defined in SPDX. The software patents issue between PD and CC0 is irrelevant for ctsa as such code is quite old and any patent would have expired anyway, plus we are on the safe side as CC0 would be more restrictive than PD in this respect).