### PR TITLE
Code cleanup and replaced calls to strcpy() by calls to strncpy()

### DIFF
--- a/header/ctsa.h
+++ b/header/ctsa.h
@@ -76,7 +76,7 @@ struct auto_arima_set{
 	double aic;
 	double bic;
 	double aicc;
-	double params[0];
+	double params[];
 };
 
 
@@ -114,7 +114,7 @@ struct sarimax_set{
 	int retval;
 	int start;
 	int imean;
-	double params[0];
+	double params[];
 };
 
 typedef struct arima_set* arima_object;
@@ -141,7 +141,7 @@ struct arima_set{
 	double loglik;
 	double aic;
 	int retval;
-	double params[0];
+	double params[];
 };
 
 typedef struct sarima_set* sarima_object;
@@ -174,7 +174,7 @@ struct sarima_set{
 	double loglik;
 	double aic;
 	int retval;
-	double params[0];
+	double params[];
 };
 
 typedef struct ar_set* ar_object;
@@ -194,7 +194,7 @@ struct ar_set{
 	double var;
 	double aic;
 	int retval;
-	double params[0];
+	double params[];
 };
 
 void sarimax_exec(sarimax_object obj, double *inp,double *xreg) ;

--- a/src/autoutils.c
+++ b/src/autoutils.c
@@ -128,7 +128,6 @@ int ndiffs(double *x, int N,double *alpha, const char *test,const char *type, in
     dodiff = runstattests(x,N,test,type,alpha_);
 
 
-    if (dodiff != dodiff) return d;
 
     y = (double*)malloc(sizeof(double)*NX);
     z = (double*)malloc(sizeof(double)*NX);
@@ -152,10 +151,6 @@ int ndiffs(double *x, int N,double *alpha, const char *test,const char *type, in
 
         //printf("dodiff %d \n",dodiff);
 
-        if (dodiff != dodiff) {
-            d--;
-            break;
-        }
 
         memcpy(y,z,sizeof(double)*NX);
     }

--- a/src/ctsa.c
+++ b/src/ctsa.c
@@ -308,10 +308,29 @@ auto_arima_object auto_arima_init(int *pdqmax,int *PDQmax,int s, int r, int N) {
 	obj->imean = 1;
 	obj->idrift = 1;
 
-	strcpy(obj->test,"kpss");
-	strcpy(obj->seas,"seas");
-	strcpy(obj->information_criteria,"aicc");
-	strcpy(obj->type,"level");
+	if (strlen("kpss") >= MAX_STR_LEN) {
+		fprintf(stderr, "String too long for obj->test (max %d chars)", MAX_STR_LEN);
+		exit(-1);
+	}
+	strncpy(obj->test, "kpss", MAX_STR_LEN - 1);
+	
+	if (strlen("seas") >= MAX_STR_LEN) {
+		fprintf(stderr, "String too long for obj->seas (max %d chars)", MAX_STR_LEN);
+		exit(-1);
+	}
+	strncpy(obj->seas, "seas", MAX_STR_LEN - 1);
+	
+	if (strlen("aicc") >= MAX_STR_LEN) {
+		fprintf(stderr, "String too long for obj->information_criteria (max %d chars)", MAX_STR_LEN);
+		exit(-1);
+	}
+	strncpy(obj->information_criteria, "aicc", MAX_STR_LEN - 1);
+	
+	if (strlen("level") >= MAX_STR_LEN) {
+		fprintf(stderr, "String too long for obj->type (max %d chars)", MAX_STR_LEN);
+		exit(-1);
+	}
+	strncpy(obj->type, "level", MAX_STR_LEN - 1);
 
 	obj->p_start = 2;
 	obj->q_start = 2;
@@ -2745,14 +2764,22 @@ void auto_arima_setSeasonal(auto_arima_object obj, int seasonal) {
 
 void auto_arima_setStationarityParameters(auto_arima_object obj,const char *test, double alpha, const char *type) {
 	if (!strcmp(test,"kpss") || !strcmp(test,"pp") || !strcmp(test,"df") || !strcmp(test,"adf")) {
-		strcpy(obj->test,test);
+		if (strlen(test) >= MAX_STR_LEN) {
+			fprintf(stderr, "String too long for obj->test (max %d chars)", MAX_STR_LEN);
+			exit(-1);
+		}
+		strncpy(obj->test, test, MAX_STR_LEN - 1);
 	} else {
 		printf("Only three tests are allowed - kpss, df and pp \n");
 		exit(-1);
 	}
 
 	if (!strcmp(type,"level") || !strcmp(type,"trend")) {
-		strcpy(obj->type,type);
+		if (strlen(type) >= MAX_STR_LEN) {
+			fprintf(stderr, "String too long for obj->type (max %d chars)", MAX_STR_LEN);
+			exit(-1);
+		}
+		strncpy(obj->type, type, MAX_STR_LEN - 1);
 	} else {
 		printf("Only two tests are allowed - level and trend \n");
 		exit(-1);
@@ -2763,7 +2790,11 @@ void auto_arima_setStationarityParameters(auto_arima_object obj,const char *test
 
 void auto_arima_setSeasonalParameters(auto_arima_object obj,const char *test, double alpha) {
 	if (!strcmp(test,"ocsb") || !strcmp(test,"seas")) {
-		strcpy(obj->seas,test);
+		if (strlen(test) >= MAX_STR_LEN) {
+			fprintf(stderr, "String too long for obj->seas (max %d chars)", MAX_STR_LEN);
+			exit(-1);
+		}
+		strncpy(obj->seas, test, MAX_STR_LEN - 1);
 	} else {
 		printf("Only two tests are allowed - seas and ocsb \n");
 		exit(-1);

--- a/src/ctsa.h
+++ b/src/ctsa.h
@@ -12,6 +12,8 @@
 #include "emle.h"
 #include "autoutils.h"
 
+#define MAX_STR_LEN 10
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -188,14 +190,14 @@ struct auto_arima_set{
 	int q_start;
 	int P_start;
 	int Q_start;
-	char information_criteria[10];
+	char information_criteria[MAX_STR_LEN];
 	int stepwise;
 	int num_models;
 	int approximation;
 	int verbose;
-	char test[10];
-	char type[10];
-	char seas[10];
+	char test[MAX_STR_LEN];
+	char type[MAX_STR_LEN];
+	char seas[MAX_STR_LEN];
 	double alpha_test;
 	double alpha_seas;
 	double lambda;

--- a/src/optimc.c
+++ b/src/optimc.c
@@ -35,7 +35,11 @@ opt_object opt_init(int N) {
 	obj->Iter = 0;
 	obj->Method = 0;
 	obj->maxstep = -1.0;
-	strcpy(obj->MethodName,"Nelder-Mead");
+	if (strlen("Nelder-Mead") >= MAX_NAME_LEN) {
+		fprintf(stderr, "String too long for obj->MethodName (max %d chars)", MAX_NAME_LEN);
+		exit(-1);
+	}
+	strncpy(obj->MethodName, "Nelder-Mead", MAX_NAME_LEN - 1);
 	obj->objfunc = 0.0;
 	for (i = 0; i < N;++i) {
 		obj->xopt[i] = 0.0;
@@ -402,46 +406,82 @@ void optimize(opt_object obj, custom_function *funcpt, custom_gradient *funcgrad
 	}
 
 	if (method == 0) {
-		strcpy(obj->MethodName,"Nelder-Mead");
+		if (strlen("Nelder-Mead") >= MAX_NAME_LEN) {
+			fprintf(stderr, "String too long for obj->MethodName (max %d chars)", MAX_NAME_LEN);
+			exit(-1);
+		}
+		strncpy(obj->MethodName, "Nelder-Mead", MAX_NAME_LEN - 1);
 		obj->retval = nel_min(funcpt,xi,obj->N,dx,fsval,obj->MaxIter,&obj->Iter,obj->eps,obj->xopt);
 	} else if (method == 1) {
-		strcpy(obj->MethodName,"Newton Line Search");
+		if (strlen("Newton Line Search") >= MAX_NAME_LEN) {
+			fprintf(stderr, "String too long for obj->MethodName (max %d chars)", MAX_NAME_LEN);
+			exit(-1);
+		}
+		strncpy(obj->MethodName, "Newton Line Search", MAX_NAME_LEN - 1);
 		obj->retval = newton_min_func(funcpt,funcgrad,xi,obj->N,dx,fsval,obj->maxstep,obj->MaxIter,&obj->Iter,obj->eps,obj->gtol,
 				obj->stol,obj->xopt);
 	} else if (method == 2) {
-		strcpy(obj->MethodName,"Newton Trust Region - Hook Step");
+		if (strlen("Newton Trust Region - Hook Step") >= MAX_NAME_LEN) {
+			fprintf(stderr, "String too long for obj->MethodName (max %d chars)", MAX_NAME_LEN);
+			exit(-1);
+		}
+		strncpy(obj->MethodName, "Newton Trust Region - Hook Step", MAX_NAME_LEN - 1);
 
 		obj->retval = newton_min_trust(funcpt,funcgrad,xi,obj->N,dx,fsval,delta,0,obj->MaxIter,&obj->Iter,obj->eps,
 				obj->gtol,obj->stol,obj->xopt);
 	} else if (method == 3) {
-		strcpy(obj->MethodName,"Newton Trust Region - Double Dog-Leg");
+		if (strlen("Newton Trust Region - Double Dog-Leg") >= MAX_NAME_LEN) {
+			fprintf(stderr, "String too long for obj->MethodName (max %d chars)", MAX_NAME_LEN);
+			exit(-1);
+		}
+		strncpy(obj->MethodName, "Newton Trust Region - Double Dog-Leg", MAX_NAME_LEN - 1);
 
 		obj->retval = newton_min_trust(funcpt,funcgrad,xi,obj->N,dx,fsval,delta,1,obj->MaxIter,&obj->Iter,obj->eps,
 				obj->gtol,obj->stol,obj->xopt);
 	} else if (method == 4) {
-		strcpy(obj->MethodName,"Conjugate Gradient");
+		if (strlen("Conjugate Gradient") >= MAX_NAME_LEN) {
+			fprintf(stderr, "String too long for obj->MethodName (max %d chars)", MAX_NAME_LEN);
+			exit(-1);
+		}
+		strncpy(obj->MethodName, "Conjugate Gradient", MAX_NAME_LEN - 1);
 
 		obj->retval = conjgrad_min_lin(funcpt, funcgrad, xi, obj->N, dx, obj->maxstep, obj->MaxIter, &obj->Iter, obj->eps, obj->gtol,
 				obj->ftol,obj->xtol,obj->xopt);
 	} else if (method == 5) {
-		strcpy(obj->MethodName,"BFGS");
+		if (strlen("BFGS") >= MAX_NAME_LEN) {
+			fprintf(stderr, "String too long for obj->MethodName (max %d chars)", MAX_NAME_LEN);
+			exit(-1);
+		}
+		strncpy(obj->MethodName, "BFGS", MAX_NAME_LEN - 1);
 
 		obj->retval = bfgs_min(funcpt, funcgrad, xi, obj->N, dx, fsval, obj->maxstep, obj->MaxIter, &obj->Iter, obj->eps, obj->gtol,
 				obj->stol,obj->xopt);
 	} else if (method == 6) {
-		strcpy(obj->MethodName,"Limited Memory BFGS");
+		if (strlen("Limited Memory BFGS") >= MAX_NAME_LEN) {
+			fprintf(stderr, "String too long for obj->MethodName (max %d chars)", MAX_NAME_LEN);
+			exit(-1);
+		}
+		strncpy(obj->MethodName, "Limited Memory BFGS", MAX_NAME_LEN - 1);
 		m = mvalue(N);
 		obj->retval = bfgs_l_min(funcpt, funcgrad, xi, obj->N, m, dx, fsval, obj->maxstep, obj->MaxIter, &obj->Iter, obj->eps,
 				obj->gtol,obj->ftol,obj->xtol,obj->xopt);
 	}
 	else if (method == 7) {
-		strcpy(obj->MethodName, "BFGS More-Thuente Line Search");
+		if (strlen("BFGS More-Thuente Line Search") >= MAX_NAME_LEN) {
+			fprintf(stderr, "String too long for obj->MethodName (max %d chars)", MAX_NAME_LEN);
+			exit(-1);
+		}
+		strncpy(obj->MethodName, "BFGS More-Thuente Line Search", MAX_NAME_LEN - 1);
 		m = mvalue(N);
 		obj->retval = bfgs_min2(funcpt, funcgrad, xi, obj->N, m, dx, fsval, obj->maxstep, obj->MaxIter, &obj->Iter, obj->eps,
 			obj->gtol, obj->ftol, obj->xtol, obj->xopt);
 	}
 	else {
-		strcpy(obj->MethodName,"NULL");
+		if (strlen("NULL") >= MAX_NAME_LEN) {
+			fprintf(stderr, "String too long for obj->MethodName (max %d chars)", MAX_NAME_LEN);
+			exit(-1);
+		}
+		strncpy(obj->MethodName, "NULL", MAX_NAME_LEN - 1);
 		printf("Method Value should be one of 0,1,2,3,4,5 or 6. See Documentation. \n");
 		exit(1);
 	}

--- a/src/optimc.h
+++ b/src/optimc.h
@@ -11,6 +11,8 @@
 
 #include "nls.h"
 
+#define MAX_NAME_LEN 50
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -32,7 +34,7 @@ struct opt_set{
 	int Iter;
 	int Method;
 	int retval;
-	char MethodName[50];
+	char MethodName[MAX_NAME_LEN];
 	double xopt[1];
 };
 

--- a/src/regression.c
+++ b/src/regression.c
@@ -36,7 +36,11 @@ reg_object reg_init(int N, int p) {
 	obj->r2adj = obj->R2[1] = 0.0;
 	obj->df = 0;
 	obj->intercept = (p == 0) ? 0 : 1;
-	strcpy(obj->lls, "qr");
+	if (strlen("qr") >= MAX_STR_LEN) {
+		fprintf(stderr, "String too long for obj->lls (max %d chars)", MAX_STR_LEN);
+		exit(-1);
+	}
+	strncpy(obj->lls, "qr", MAX_STR_LEN - 1);
 
 	obj->TSS = 0.0;
 	obj->ESS = 0.0;
@@ -508,14 +512,26 @@ void setIntercept(reg_object obj, int intercept) {
 
 void setLLSMethod(reg_object obj, char *llsmethod) {
 	if (!strcmp(llsmethod, "qr")) {
-		strcpy(obj->lls, llsmethod);
+		if (strlen(llsmethod) >= MAX_STR_LEN) {
+			fprintf(stderr, "String too long for obj->lls (max %d chars)", MAX_STR_LEN);
+			exit(-1);
+		}
+		strncpy(obj->lls, llsmethod, MAX_STR_LEN - 1);
 	}
 	else if (!strcmp(llsmethod, "normal")) {
-		strcpy(obj->lls, llsmethod);
+		if (strlen(llsmethod) >= MAX_STR_LEN) {
+			fprintf(stderr, "String too long for obj->lls (max %d chars)", MAX_STR_LEN);
+			exit(-1);
+		}
+		strncpy(obj->lls, llsmethod, MAX_STR_LEN - 1);
 		printf("Warning - This method will not calculate the rank of the regression. Use method qr instead. \n");
 	}
 	else if (!strcmp(llsmethod, "svd")) {
-		strcpy(obj->lls, llsmethod);
+		if (strlen(llsmethod) >= MAX_STR_LEN) {
+			fprintf(stderr, "String too long for obj->lls (max %d chars)", MAX_STR_LEN);
+			exit(-1);
+		}
+		strncpy(obj->lls, llsmethod, MAX_STR_LEN - 1);
 		printf("Warning - This method will not calculate the rank of the regression. use method qr instead. \n");
 	}
 	else {

--- a/src/regression.h
+++ b/src/regression.h
@@ -11,6 +11,8 @@
 
 #include "stats.h"
 
+#define MAX_STR_LEN 10
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -36,7 +38,7 @@ struct reg_set{
 	double r2;
 	double r2adj;
 	double R2[2];
-	char lls[10];
+	char lls[MAX_STR_LEN];
 	int df;
 	int intercept;
 	int rank; // Use method "qr" to calculate the rank

--- a/src/seastest.c
+++ b/src/seastest.c
@@ -670,7 +670,7 @@ void OCSBtest(double *x, int N, int f, int mlags, const char *method,double *sta
 
     //printf("\n\n%d\n\n",fit->rank);
 
-    if (fit->rank != fit->p && fit->rank == fit->rank) {
+    if (fit->rank != fit->p) {
         if (crit_reg == NULL) {
             printf("Could not find a solution. Try a different method. \n");
             exit(-1);

--- a/src/wavelib.c
+++ b/src/wavelib.c
@@ -25,9 +25,15 @@ wave_object wave_init(const char* wname) {
 
 	obj->filtlength = retval;
 	obj->lpd_len = obj->hpd_len = obj->lpr_len = obj->hpr_len = obj->filtlength;
-	strcpy(obj->wname, wname);
 	if (wname != NULL) {
+		if (strlen(wname) >= MAX_WNAME_LEN) {
+			fprintf(stderr, "String too long for obj->wname (max %d chars)", MAX_WNAME_LEN);
+			exit(-1);
+		}
+		strncpy(obj->wname, wname, MAX_WNAME_LEN - 1);
 		filtcoef(wname,obj->params,obj->params+retval,obj->params+2*retval,obj->params+3*retval);
+	} else {
+		obj->wname[0] = '\0';
 	}
 	obj->lpd = &obj->params[0];
 	obj->hpd = &obj->params[retval];
@@ -57,12 +63,20 @@ wt_object wt_init(wave_object wave,const char* method, int siglength,int J) {
 	if (method == NULL) {
 		obj = (wt_object)malloc(sizeof(struct wt_set) + sizeof(double)* (siglength +  2 * J * (size+1)));
 		obj->outlength = siglength + 2 * J * (size + 1); // Default
-		strcpy(obj->ext, "sym"); // Default
+		if (strlen("sym") >= MAX_EXT_LEN) {
+			fprintf(stderr, "String too long for obj->ext (max %d chars)", MAX_EXT_LEN);
+			exit(-1);
+		}
+		strncpy(obj->ext, "sym", MAX_EXT_LEN - 1);
 	}
 	else if (!strcmp(method, "dwt") || !strcmp(method, "DWT")) {
 		obj = (wt_object)malloc(sizeof(struct wt_set) + sizeof(double)* (siglength + 2 * J * (size + 1)));
 		obj->outlength = siglength + 2 * J * (size + 1); // Default
-		strcpy(obj->ext, "sym"); // Default
+		if (strlen("sym") >= MAX_EXT_LEN) {
+			fprintf(stderr, "String too long for obj->ext (max %d chars)", MAX_EXT_LEN);
+			exit(-1);
+		}
+		strncpy(obj->ext, "sym", MAX_EXT_LEN - 1);
 	}
 	else if (!strcmp(method, "swt") || !strcmp(method, "SWT")) {
 		if (!testSWTlength(siglength, J)) {
@@ -72,7 +86,11 @@ wt_object wt_init(wave_object wave,const char* method, int siglength,int J) {
 
 		obj = (wt_object)malloc(sizeof(struct wt_set) + sizeof(double)* (siglength * (J + 1)));
 		obj->outlength = siglength * (J + 1); // Default
-		strcpy(obj->ext, "per"); // Default
+		if (strlen("per") >= MAX_EXT_LEN) {
+			fprintf(stderr, "String too long for obj->ext (max %d chars)", MAX_EXT_LEN);
+			exit(-1);
+		}
+		strncpy(obj->ext, "per", MAX_EXT_LEN - 1);
 	}
 	else if (!strcmp(method, "modwt") || !strcmp(method, "MODWT")) {
 
@@ -89,7 +107,11 @@ wt_object wt_init(wave_object wave,const char* method, int siglength,int J) {
 
 		obj = (wt_object)malloc(sizeof(struct wt_set) + sizeof(double)* (siglength * 2 * (J + 1)));
 		obj->outlength = siglength * (J + 1); // Default
-		strcpy(obj->ext, "per"); // Default
+		if (strlen("per") >= MAX_EXT_LEN) {
+			fprintf(stderr, "String too long for obj->ext (max %d chars)", MAX_EXT_LEN);
+			exit(-1);
+		}
+		strncpy(obj->ext, "per", MAX_EXT_LEN - 1);
 	}
 
 	obj->wave = wave;
@@ -97,7 +119,15 @@ wt_object wt_init(wave_object wave,const char* method, int siglength,int J) {
 	obj->modwtsiglength = siglength;
 	obj->J = J;
 	obj->MaxIter = MaxIter;
-	strcpy(obj->method, method);
+	if (method != NULL) {
+		if (strlen(method) >= MAX_METHOD_LEN) {
+			fprintf(stderr, "String too long for obj->method (max %d chars)", MAX_METHOD_LEN);
+			exit(-1);
+		}
+		strncpy(obj->method, method, MAX_METHOD_LEN - 1);
+	} else {
+		obj->method[0] = '\0';
+	}
 
 	if (siglength % 2 == 0) {
 		obj->even = 1;
@@ -108,7 +138,12 @@ wt_object wt_init(wave_object wave,const char* method, int siglength,int J) {
 
 	obj->cobj = NULL;
 
-	strcpy(obj->cmethod, "direct"); // Default
+	if (strlen("direct") >= MAX_METHOD_LEN) {
+		fprintf(stderr, "String too long for obj->cmethod (max %d chars)", MAX_CMETHOD_LEN);
+		exit(-1);
+	}
+	strncpy(obj->cmethod, "direct", MAX_METHOD_LEN - 1);
+
 	obj->cfftset = 0;
 	obj->lenlength = J + 2;
 	obj->output = &obj->params[0];
@@ -161,13 +196,21 @@ wtree_object wtree_init(wave_object wave, int siglength,int J) {
 
 	obj = (wtree_object)malloc(sizeof(struct wtree_set) + sizeof(double)* (siglength * (J + 1) + elength + nodes + J + 1));
 	obj->outlength = siglength * (J + 1) + elength;
-	strcpy(obj->ext, "sym");
+	if (strlen("sym") >= MAX_EXT_LEN) {
+		fprintf(stderr, "String too long for obj->ext (max %d chars)", MAX_EXT_LEN);
+		exit(-1);
+	}
+	strncpy(obj->ext, "sym", MAX_EXT_LEN - 1);
 
 	obj->wave = wave;
 	obj->siglength = siglength;
 	obj->J = J;
 	obj->MaxIter = MaxIter;
-	strcpy(obj->method, "dwt");
+	if (strlen("dwt") >= MAX_METHOD_LEN) {
+		fprintf(stderr, "String too long for obj->method (max %d chars)", MAX_METHOD_LEN);
+		exit(-1);
+	}
+	strncpy(obj->method, "dwt", MAX_METHOD_LEN - 1);
 
 	if (siglength % 2 == 0) {
 		obj->even = 1;
@@ -234,8 +277,16 @@ wpt_object wpt_init(wave_object wave, int siglength, int J) {
 
 	obj = (wpt_object)malloc(sizeof(struct wpt_set) + sizeof(double)* (elength + 4 * nodes + 2 * J + 6));
 	obj->outlength = siglength + 2 * (J + 1) * (size + 1);
-	strcpy(obj->ext, "sym");
-	strcpy(obj->entropy, "shannon");
+	if (strlen("sym") >= MAX_EXT_LEN) {
+		fprintf(stderr, "String too long for obj->ext (max %d chars)", MAX_EXT_LEN);
+		exit(-1);
+	}
+	strncpy(obj->ext, "sym", MAX_EXT_LEN - 1);
+	if (strlen("shannon") >= MAX_ENTROPY_LEN) {
+		fprintf(stderr, "String too long for obj->entropy (max %d chars)", MAX_ENTROPY_LEN);
+		exit(-1);
+	}
+	strncpy(obj->entropy, "shannon", MAX_ENTROPY_LEN - 1);
 	obj->eparam = 0.0;
 
 	obj->wave = wave;
@@ -2966,10 +3017,18 @@ void imodwt(wt_object wt, double *oup) {
 
 void setDWTExtension(wt_object wt, const char *extension) {
 	if (!strcmp(extension, "sym")) {
-		strcpy(wt->ext, "sym");
+		if (strlen("sym") >= MAX_EXT_LEN) {
+			fprintf(stderr, "String too long for wt->ext (max %d chars)", MAX_EXT_LEN);
+			exit(-1);
+		}
+		strncpy(wt->ext, "sym", MAX_EXT_LEN - 1);
 	}
 	else if (!strcmp(extension, "per")) {
-		strcpy(wt->ext, "per");
+		if (strlen("per") >= MAX_EXT_LEN) {
+			fprintf(stderr, "String too long for wt->ext (max %d chars)", MAX_EXT_LEN);
+			exit(-1);
+		}
+		strncpy(wt->ext, "per", MAX_EXT_LEN - 1);
 	}
 	else {
 		printf("Signal extension can be either per or sym");
@@ -2979,10 +3038,18 @@ void setDWTExtension(wt_object wt, const char *extension) {
 
 void setWTREEExtension(wtree_object wt, const char *extension) {
 	if (!strcmp(extension, "sym")) {
-		strcpy(wt->ext, "sym");
+		if (strlen("sym") >= MAX_EXT_LEN) {
+			fprintf(stderr, "String too long for wt->ext (max %d chars)", MAX_EXT_LEN);
+			exit(-1);
+		}
+		strncpy(wt->ext, "sym", MAX_EXT_LEN - 1);
 	}
 	else if (!strcmp(extension, "per")) {
-		strcpy(wt->ext, "per");
+		if (strlen("per") >= MAX_EXT_LEN) {
+			fprintf(stderr, "String too long for wt->ext (max %d chars)", MAX_EXT_LEN);
+			exit(-1);
+		}
+		strncpy(wt->ext, "per", MAX_EXT_LEN - 1);
 	}
 	else {
 		printf("Signal extension can be either per or sym");
@@ -2992,10 +3059,18 @@ void setWTREEExtension(wtree_object wt, const char *extension) {
 
 void setDWPTExtension(wpt_object wt, const char *extension) {
 	if (!strcmp(extension, "sym")) {
-		strcpy(wt->ext, "sym");
+		if (strlen("sym") >= MAX_EXT_LEN) {
+			fprintf(stderr, "String too long for wt->ext (max %d chars)", MAX_EXT_LEN);
+			exit(-1);
+		}
+		strncpy(wt->ext, "sym", MAX_EXT_LEN - 1);
 	}
 	else if (!strcmp(extension, "per")) {
-		strcpy(wt->ext, "per");
+		if (strlen("per") >= MAX_EXT_LEN) {
+			fprintf(stderr, "String too long for wt->ext (max %d chars)", MAX_EXT_LEN);
+			exit(-1);
+		}
+		strncpy(wt->ext, "per", MAX_EXT_LEN - 1);
 	}
 	else {
 		printf("Signal extension can be either per or sym");
@@ -3005,18 +3080,34 @@ void setDWPTExtension(wpt_object wt, const char *extension) {
 
 void setDWPTEntropy(wpt_object wt, const char *entropy, double eparam) {
 	if (!strcmp(entropy, "shannon")) {
-		strcpy(wt->entropy, "shannon");
+		if (strlen("shannon") >= MAX_ENTROPY_LEN) {
+			fprintf(stderr, "String too long for wt->entropy (max %d chars)", MAX_ENTROPY_LEN);
+			exit(-1);
+		}
+		strncpy(wt->entropy, "shannon", MAX_ENTROPY_LEN - 1);
 	}
 	else if (!strcmp(entropy, "threshold")) {
-		strcpy(wt->entropy, "threshold");
+		if (strlen("threshold") >= MAX_ENTROPY_LEN) {
+			fprintf(stderr, "String too long for wt->entropy (max %d chars)", MAX_ENTROPY_LEN);
+			exit(-1);
+		}
+		strncpy(wt->entropy, "threshold", MAX_ENTROPY_LEN - 1);
 		wt ->eparam = eparam;
 	}
 	else if (!strcmp(entropy, "norm")) {
-		strcpy(wt->entropy, "norm");
+		if (strlen("norm") >= MAX_ENTROPY_LEN) {
+			fprintf(stderr, "String too long for wt->entropy (max %d chars)", MAX_ENTROPY_LEN);
+			exit(-1);
+		}
+		strncpy(wt->entropy, "norm", MAX_ENTROPY_LEN - 1);
 		wt->eparam = eparam;
 	}
 	else if (!strcmp(entropy, "logenergy") || !strcmp(entropy, "log energy") || !strcmp(entropy, "energy")) {
-		strcpy(wt->entropy, "logenergy");
+		if (strlen("logenergy") >= MAX_ENTROPY_LEN) {
+			fprintf(stderr, "String too long for wt->entropy (max %d chars)", MAX_ENTROPY_LEN);
+			exit(-1);
+		}
+		strncpy(wt->entropy, "logenergy", MAX_ENTROPY_LEN - 1);
 	}
 	else {
 		printf("Entropy should be one of shannon, threshold, norm or logenergy");
@@ -3026,10 +3117,18 @@ void setDWPTEntropy(wpt_object wt, const char *entropy, double eparam) {
 
 void setWTConv(wt_object wt, const char *cmethod) {
 	if (!strcmp(cmethod, "fft") || !strcmp(cmethod, "FFT")) {
-		strcpy(wt->cmethod, "fft");
+		if (strlen("fft") >= MAX_METHOD_LEN) {
+			fprintf(stderr, "String too long for wt->cmethod (max %d chars)", MAX_CMETHOD_LEN);
+			exit(-1);
+		}
+		strncpy(wt->cmethod, "fft", MAX_METHOD_LEN - 1);
 	}
 	else if (!strcmp(cmethod, "direct")) {
-		strcpy(wt->cmethod, "direct");
+		if (strlen("direct") >= MAX_METHOD_LEN) {
+			fprintf(stderr, "String too long for wt->cmethod (max %d chars)", MAX_CMETHOD_LEN);
+			exit(-1);
+		}
+		strncpy(wt->cmethod, "direct", MAX_METHOD_LEN - 1);
 	}
 	else {
 		printf("Convolution Only accepts two methods - direct and fft");

--- a/src/wavelib.h
+++ b/src/wavelib.h
@@ -4,6 +4,11 @@
 
 #include "wtmath.h"
 
+#define MAX_WNAME_LEN 50
+#define MAX_METHOD_LEN 10
+#define MAX_EXT_LEN 10
+#define MAX_CMETHOD_LEN 10
+#define MAX_ENTROPY_LEN 20
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,7 +38,7 @@ typedef struct wave_set* wave_object;
 wave_object wave_init(const char* wname);
 
 struct wave_set{
-	char wname[50];
+	char wname[MAX_WNAME_LEN];
 	int filtlength;// When all filters are of the same length. [Matlab uses zero-padding to make all filters of the same length]
 	int lpd_len;// Default filtlength = lpd_len = lpr_len = hpd_len = hpr_len
 	int hpd_len;
@@ -53,7 +58,7 @@ wt_object wt_init(wave_object wave,const char* method, int siglength, int J);
 struct wt_set{
 	wave_object wave;
 	conv_object cobj;
-	char method[10];
+	char method[MAX_METHOD_LEN];
 	int siglength;// Length of the original signal.
 	int modwtsiglength; // Modified signal length for MODWT
 	int outlength;// Length of the output DWT vector
@@ -61,8 +66,8 @@ struct wt_set{
 	int J; // Number of decomposition Levels
 	int MaxIter;// Maximum Iterations J <= MaxIter
 	int even;// even = 1 if signal is of even length. even = 0 otherwise
-	char ext[10];// Type of Extension used - "per" or "sym"
-	char cmethod[10]; // Convolution Method - "direct" or "FFT"
+	char ext[MAX_EXT_LEN];// Type of Extension used - "per" or "sym"
+	char cmethod[MAX_CMETHOD_LEN]; // Convolution Method - "direct" or "FFT"
 
 	int N; //
 	int cfftset;
@@ -79,14 +84,14 @@ wtree_object wtree_init(wave_object wave, int siglength, int J);
 struct wtree_set{
 	wave_object wave;
 	conv_object cobj;
-	char method[10];
+	char method[MAX_METHOD_LEN];
 	int siglength;// Length of the original signal.
 	int outlength;// Length of the output DWT vector
 	int lenlength;// Length of the Output Dimension Vector "length"
 	int J; // Number of decomposition Levels
 	int MaxIter;// Maximum Iterations J <= MaxIter
 	int even;// even = 1 if signal is of even length. even = 0 otherwise
-	char ext[10];// Type of Extension used - "per" or "sym"
+	char ext[MAX_EXT_LEN];// Type of Extension used - "per" or "sym"
 
 	int N; //
 	int nodes;
@@ -112,8 +117,8 @@ struct wpt_set{
 	int J; // Number of decomposition Levels
 	int MaxIter;// Maximum Iterations J <= MaxIter
 	int even;// even = 1 if signal is of even length. even = 0 otherwise
-	char ext[10];// Type of Extension used - "per" or "sym"
-	char entropy[20];
+	char ext[MAX_EXT_LEN];// Type of Extension used - "per" or "sym"
+	char entropy[MAX_ENTROPY_LEN];
 	double eparam;
 
 	int N; //


### PR DESCRIPTION
Some dead code (tests that are always true) has been removed. The arrays are now using a more modern syntax (so compilers don't complain anymore). 

Finally, static analysis always complained about uses of 'strcpy'. Although this is very low risk for ctsa (all calls are done with developer provided, hard coded strings), there is a somehow remote possibility of problems happening in the future if a developer is not careful enough (initializing a string with a value that is too long). But instead of only replacing strcpy by strncpy (which would silence the warnings but lead to random error messages  because the strings would be truncated), this commit replaced all calls to strcpy by a check on the string length against the length of its destination and a appropriate error message if this would not fit. And then strncpy is called (although there is no risk of buffer overflow anymore, thanks to the test before, this is needed to silence static analysis).

If you find the strcpy() -> strncpy() replacement too intrusive, please let me know and I can make a separate pull request for the dead code and the arrays.